### PR TITLE
CI: fix release asset upload token permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -69,5 +69,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: memoryalpha-rag-api-spec.json
-      env:
-        GITHUB_TOKEN: ${{ secrets.MEMORYALPHA_RAG_API_MODIFY_RELEASE_TOKEN }}
+        # Must be passed as the `token` input; a token here overrides the
+        # GITHUB_TOKEN env, whereas the input's default (github.token) would
+        # otherwise win and lacks release-write permission.
+        token: ${{ secrets.MEMORYALPHA_RAG_API_MODIFY_RELEASE_TOKEN }}


### PR DESCRIPTION
## Problem

The `Release Docker Image` workflow failed on v0.63 at the **Upload OpenAPI spec to release** step with:

```
Resource not accessible by integration - https://docs.github.com/rest/releases/releases#update-a-release
```

The image built and pushed fine; only the release-asset upload failed.

## Root cause

The dedicated `MEMORYALPHA_RAG_API_MODIFY_RELEASE_TOKEN` was passed to `softprops/action-gh-release@v2` as a `GITHUB_TOKEN` **env var**. But that action's `token` **input** defaults to `github.token`, and per its docs *"A non-empty explicit token overrides GITHUB_TOKEN."* So the default token won — and the workflow only granted it `contents: read`, which can't modify releases.

## Fix

- Pass the PAT as the `token` **input** under `with:` (so it's actually used).
- Bump workflow `permissions` to `contents: write` as a fallback so the default token can also write releases.

Unrelated to the earlier port fix (the OpenAPI-generate step passed). After merge, cut a new release to verify the asset uploads.